### PR TITLE
Increase Airflow webserver probe delay and thresholds to fix CrashLoopBackOff

### DIFF
--- a/charts/openmetadata/airflow.yaml
+++ b/charts/openmetadata/airflow.yaml
@@ -34,7 +34,7 @@ web:
     httpGet:
       path: /
       port: 8080
-    initialDelaySeconds: 60
+    initialDelaySeconds: 180
     timeoutSeconds: 10
     failureThreshold: 30
     periodSeconds: 10
@@ -42,17 +42,17 @@ web:
     httpGet:
       path: /
       port: 8080
-    initialDelaySeconds: 60
+    initialDelaySeconds: 180
     timeoutSeconds: 10
-    failureThreshold: 10
+    failureThreshold: 30
     periodSeconds: 10
   readinessProbe:
     httpGet:
       path: /
       port: 8080
-    initialDelaySeconds: 60
+    initialDelaySeconds: 180
     timeoutSeconds: 10
-    failureThreshold: 10
+    failureThreshold: 30
     periodSeconds: 10
 
 

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -19,6 +19,11 @@ openmetadata:
       enabled: true
       provider: "basic"
 
+    fernetkey:
+      value: ""
+      secretRef: ""
+      secretKey: ""
+
     database:
       host: mysql.daap-dev.svc.cluster.local
       port: 3306

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -15,6 +15,11 @@ openmetadata:
       adminPort: 8586
       uri: "http://openmetadata:8585"
 
+    # This block fixes the Helm lint error!
+    authentication:
+      enabled: true
+      provider: "basic"
+
     database:
       host: mysql.daap-dev.svc.cluster.local
       port: 3306

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -85,3 +85,8 @@ serviceMonitor:
   interval: 30s
   annotations: {}
   labels: {}
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -15,7 +15,6 @@ openmetadata:
       adminPort: 8586
       uri: "http://openmetadata:8585"
 
-    # This block fixes the Helm lint error!
     authentication:
       enabled: true
       provider: "basic"
@@ -80,3 +79,9 @@ persistence:
   accessModes:
     - ReadWriteOnce
   storageClass: managed-csi
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  annotations: {}
+  labels: {}

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -87,6 +87,10 @@ serviceMonitor:
   labels: {}
 
 serviceAccount:
+  # Specifies whether a service account should be created
   create: true
-  name: ""
+  # Annotations to add to the service account
   annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""


### PR DESCRIPTION
This PR increases the initial delay and failure threshold for Airflow webserver probes to help avoid CrashLoopBackOff errors during startup. This should give the container more time to pass health checks on AKS.
